### PR TITLE
Fix 7 critical validation bugs (with tests)

### DIFF
--- a/lib/Valiant/Error.pm
+++ b/lib/Valiant/Error.pm
@@ -315,6 +315,7 @@ sub clone {
 sub strict_match {
   my ($self, $attribute, $type, $options) = @_;
   return 0 unless $self->match($attribute, $type);
+  return 1 unless defined $options;
 
   # This is different from match because ALL the keys/values in options need to match
   # exactly.  Its possible my approach here is suspect around object comparisons.

--- a/lib/Valiant/Errors.pm
+++ b/lib/Valiant/Errors.pm
@@ -250,7 +250,6 @@ sub add {
   if(my $exception = $options->{strict}) {
     my $message = $error->full_message;
     throw_exception('Strict' => (msg=>$message)) if $exception =~m/^\d+$/ && $exception == 1;
-    throw_exception('Strict' => (msg=>$exception)) if( (ref(\$exception)||'') eq 'SCALAR');
     $exception->($self->object, $message) if( (ref($exception)||'') eq 'CODE');
     $exception->throw($message); # If not 1 then assume its a package name or exception object.
   }

--- a/lib/Valiant/Errors.pm
+++ b/lib/Valiant/Errors.pm
@@ -80,6 +80,7 @@ sub import_error {
       inner_error => $error,
       object => $error->object,
       attribute => $error->attribute,
+      type => $error->type,
       %{ $options||+{} },
     )
   );

--- a/lib/Valiant/Filter/UcFirst.pm
+++ b/lib/Valiant/Filter/UcFirst.pm
@@ -13,6 +13,7 @@ sub normalize_shortcut {
 sub filter_each {
   my ($self, $class, $attrs, $attribute_name) = @_;  
   my $value = $attrs->{$attribute_name};
+  return unless defined $value;
   return ucfirst $value;
 }
 

--- a/lib/Valiant/Filter/Upper.pm
+++ b/lib/Valiant/Filter/Upper.pm
@@ -13,6 +13,7 @@ sub normalize_shortcut {
 sub filter_each {
   my ($self, $class, $attrs, $attribute_name) = @_;  
   my $value = $attrs->{$attribute_name};
+  return unless defined $value;
   return uc $value;
 }
 

--- a/lib/Valiant/Validator/Check.pm
+++ b/lib/Valiant/Validator/Check.pm
@@ -2,10 +2,20 @@ package Valiant::Validator::Check;
 
 use Moo;
 use Valiant::I18N;
+use Scalar::Util 'blessed';
 
 with 'Valiant::Validator::Each';
 
-has constraint => (is=>'ro', required=>1, isa=>sub {shift->can('check')});
+has constraint => (is=>'ro', required=>1, isa=>sub {
+  my $value = shift;
+  my $ref = ref($value) || '';
+  return if $ref eq 'CODE';
+  my @constraints = $ref eq 'ARRAY' ? @$value : ($value);
+  foreach my $constraint (@constraints) {
+    die "constraint must be an object (or arrayref of objects) that can 'check'"
+      unless blessed($constraint) && $constraint->can('check');
+  }
+});
 has check => (is=>'ro', required=>1, default=>sub {_t 'check'});
 
 sub normalize_shortcut {

--- a/lib/Valiant/Validator/Numericality.pm
+++ b/lib/Valiant/Validator/Numericality.pm
@@ -68,12 +68,12 @@ around BUILDARGS => sub {
     }
 
     if($integer eq 'pg_serial') {
-      $args->{greater_than_or_equal_to} = 0;
-      $args->{less_than_or_equal_to} = 0;
+      $args->{greater_than_or_equal_to} = 1;
+      $args->{less_than_or_equal_to} = 2147483647;
       $args->{message} = _t("pg_serial_err") unless defined $args->{message};
     }
     if($integer eq 'pg_bigserial') {
-      $args->{greater_than_or_equal_to} = 2147483647;
+      $args->{greater_than_or_equal_to} = 1;
       $args->{less_than_or_equal_to} = 9223372036854775807;
       $args->{message} = _t("pg_bigserial_err") unless defined $args->{message};
     }

--- a/lib/Valiant/Validator/OnlyOf.pm
+++ b/lib/Valiant/Validator/OnlyOf.pm
@@ -29,7 +29,7 @@ sub validate_each {
   push @group_values, $value;
 
   my $count_not_blank = grep {
-    defined $_ && ( $_ ne '' || $value !~m/^\s+$/)
+    defined $_ && ( $_ ne '' && $_ !~m/^\s+$/)
   } @group_values;
 
   my $max_allowed = $self->_cb_value($record, $self->max_allowed);

--- a/lib/Valiant/Validator/locale/errors.pl
+++ b/lib/Valiant/Validator/locale/errors.pl
@@ -21,8 +21,8 @@
         negative_integer_err => 'must be a negative integer',
         positive_err => 'must be a positive number',
         negative_err => 'must be a negative number',
-        pg_serial => 'is not in acceptable value range',
-        pg_bigserial => 'is not in acceptable value range',
+        pg_serial_err => 'is not in acceptable value range',
+        pg_bigserial_err => 'is not in acceptable value range',
         # length
         too_short => {
           one => 'is too short (minimum is 1 character)',

--- a/t/errors.t
+++ b/t/errors.t
@@ -297,6 +297,10 @@ is_deeply [$errors->errors->full_attribute_messages], [
   "Name has wrong value",
 ];
 
+my ($imported) = ($errors->errors->errors->all)[-1];
+is $imported->raw_type, 'is always in error!',
+  'import_error preserves the original error type instead of defaulting to invalid';
+
 my @results = map { $_->full_message } $errors->errors->where('name');
 is_deeply \@results, [
   "Name is too short",

--- a/t/errors.t
+++ b/t/errors.t
@@ -1,4 +1,5 @@
 use Test::Most;
+use Valiant::I18N;
 
 {
   package Local::Object::User;
@@ -108,6 +109,11 @@ is_deeply +{ $user1->errors->to_hash }, +{
 
 ok $user2->errors->of_kind('test01', "Is Invalid");
 ok ! $user2->errors->of_kind('test0x', "Is Invalid");
+
+ok $user2->errors->of_kind('test01', _t('invalid')),
+  'of_kind matches a tag-typed error while ignoring its stored options';
+ok $user2->errors->added('test01', _t('invalid')),
+  'added matches a tag-typed error while ignoring its stored options';
 
 is_deeply [$user2->errors->full_messages], [
     "test01 another test error1",

--- a/t/filters/case.t
+++ b/t/filters/case.t
@@ -11,23 +11,34 @@ use Test::Most;
   has 'upper' => (is=>'ro', required=>1);
   has 'lower' => (is=>'ro', required=>1);
   has 'title' => (is=>'ro', required=>1);
+  has 'nickname' => (is=>'ro', default=>'anon');
+  has 'callsign' => (is=>'ro', default=>'anon');
 
   filters uc_first => (uc_first => 1);
   filters upper => (upper => 1);
   filters lower => (lower => 1);
   filters title => (title => 1);
+  filters nickname => (upper => 1);
+  filters callsign => (uc_first => 1);
 }
 
-my $user = Local::Test::User->new(
-  uc_first=>'john',
-  upper=>'john',
-  lower=>'JOHN',
-  title=>'john NAPIORKOWSKI',
-);
+my @warnings;
+my $user = do {
+  local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+  Local::Test::User->new(
+    uc_first=>'john',
+    upper=>'john',
+    lower=>'JOHN',
+    title=>'john NAPIORKOWSKI',
+  );
+};
 
 is $user->uc_first, 'John';
 is $user->upper, 'JOHN';
 is $user->lower, 'john';
 is $user->title, 'John Napiorkowski';
+is $user->nickname, undef, 'an omitted upper-filtered attribute is left undef, not clobbered with ""';
+is $user->callsign, undef, 'an omitted uc_first-filtered attribute is left undef, not clobbered with ""';
+is_deeply \@warnings, [], 'omitting a filtered attribute does not raise an uninitialized-value warning';
 
 done_testing;

--- a/t/strict.t
+++ b/t/strict.t
@@ -25,7 +25,7 @@ use Test::Most;
       is_integer => 1,
       greater_than_or_equal_to => 18,
     },
-    strict => "Too Young",
+    strict => "Local::Test::Strict::TooYoung",
     allow_undef => 1,
   );
 
@@ -46,6 +46,11 @@ use Test::Most;
 }
 
 {
+  package Local::Test::Strict::TooYoung;
+  sub throw { my ($class, $message) = @_; die "Too Young: $message" }
+}
+
+{
   ok my $object = Local::Test::Strict->new(age=>1110);
   ok !eval { $object->validate };
   ok $@ =~m/^Age must be less than 200/;
@@ -54,7 +59,7 @@ use Test::Most;
 {
   ok my $object = Local::Test::Strict->new(age=>11);
   ok !eval { $object->validate };
-  ok $@ =~m/^Too Young/;
+  ok $@ =~m/^Too Young: Age must be greater than or equal to 18/;
 }
 
 {

--- a/t/validator/check.t
+++ b/t/validator/check.t
@@ -80,4 +80,32 @@ use Test::Needs 'Types::Standard';
     };
 }
 
+{
+  ok eval {
+    package Local::Test::Check::Dynamic;
+
+    use Moo;
+    use Valiant::Validations;
+    use Types::Standard 'Int';
+
+    has age => (is=>'ro');
+
+    validates age => (
+      check => { constraint => sub { Int->where('$_ >= 65') } },
+    );
+
+    1;
+  }, 'a coderef constraint can be declared without crashing' or diag $@;
+}
+
+{
+  ok my $object = Local::Test::Check::Dynamic->new(age=>80);
+  ok $object->validate->valid;
+}
+
+{
+  ok my $object = Local::Test::Check::Dynamic->new(age=>40);
+  ok $object->validate->invalid;
+}
+
 done_testing;

--- a/t/validator/numericality.t
+++ b/t/validator/numericality.t
@@ -87,4 +87,27 @@ use Test::Most;
     };
 }
 
+{
+  package Local::Test::Numericality::PgSerial;
+
+  use Moo;
+  use Valiant::Validations;
+
+  has id => (is=>'ro');
+
+  validates id => (numericality => 'pg_serial');
+}
+
+{
+  ok my $object = Local::Test::Numericality::PgSerial->new(id=>0);
+  ok $object->validate->invalid, 'serial ids start at 1, so 0 is out of range';
+  is_deeply +{ $object->errors->to_hash(full_messages=>1) },
+    { id => [ "Id is not in acceptable value range" ] };
+}
+
+{
+  ok my $object = Local::Test::Numericality::PgSerial->new(id=>5);
+  ok $object->validate->valid, 'a real pg_serial value like 5 must validate cleanly';
+}
+
 done_testing;

--- a/t/validator/only_of.t
+++ b/t/validator/only_of.t
@@ -31,4 +31,11 @@ use Test::Most;
   };
 }
 
+{
+  # A sibling field holding '' (the normal HTML-form case for an unfilled
+  # optional field) must NOT count as filled.
+  ok my $object = Local::Test::OnlyOf->new(opt1=>'aaa', opt2=>'');
+  ok $object->validate->valid, 'an empty-string sibling does not count against max_allowed';
+}
+
 done_testing;


### PR DESCRIPTION
Fixes the 7 critical bugs from the code review, each with a regression test written to fail before the fix (the common thread was zero test coverage on the affected path):

1. `errors->added`/`of_kind` for i18n-tag errors (strict_match vs undef)
2. `numericality => 'pg_serial'`/`'pg_bigserial'` bounds + locale keys
3. `strict => 'Class'` routing
4. `OnlyOf` counting empty/whitespace as filled
5. `Check` validator coderef/arrayref forms
6. `Filter::Upper`/`UcFirst` undef guard
7. `import_error`/`merge` preserving error type

Each was reproduced live before fixing. Suite: **61 files / 738 tests PASS** (up 18 from the new tests). Two existing tests were corrected where they had been passing only *because* of a bug (`t/strict.t`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)