### PR TITLE
Fix pre-existing POD errors (V<>, M<>, =over4, dead links, phantom Valiant::Class)

### DIFF
--- a/lib/Valiant/HTML/FormBuilder.pm
+++ b/lib/Valiant/HTML/FormBuilder.pm
@@ -2622,7 +2622,7 @@ using the C<container_tag> option.  For example:
 Here's all the values for the '%options' argument.  Any options that are not one of these will be passed to 
 the container tag as html attributes:
 
-=over4
+=over 4
 
 =item checked_value
 

--- a/lib/Valiant/Proxy.pm
+++ b/lib/Valiant/Proxy.pm
@@ -52,9 +52,9 @@ Valiant::Proxy - Create a validation ruleset dynamically
 
 =head1 SYNOPSIS
 
-    my $validator = Valiant::Class->new(
+    my $validator = Valiant::Proxy::Object->new(
       validations => [
-        [ sub { unless($_[0]->is_active) { $_[0]->errors->add(_base=>'Cannot change inactive user') } } ],
+        sub { unless($_[0]->is_active) { $_[0]->errors->add(undef, 'Cannot change inactive user') } },
         [ name => length => [2,15], format => qr/[a-zA-Z ]+/ ],
         [ age => numericality => 'positive_integer' ],
       ]
@@ -92,11 +92,11 @@ that has no validation rules of its own:
     warn $result->errors->_dump;
 
     $VAR = {
-      '_base' => [
-                   'Cannot change inactive user'
-                 ],
+      '*' => [
+               'Cannot change inactive user'
+             ],
       'age' => [
-                 'Age must be greater than or equal to zero'
+                 'Age must be a positive integer'
                ],
       'name' => [
                   'Name does not match the required pattern'

--- a/lib/Valiant/Proxy/Array.pm
+++ b/lib/Valiant/Proxy/Array.pm
@@ -34,8 +34,7 @@ Valiant::Proxy::Array - Wrap an arrayref in a result object for validation.
 
 Allows you to run validations against an ArrayRef.
 
-You probably won't use this directly (although you can) since we have L<Valiant::Class> to
-encapsulate the most common patterns for this need.
+You probably won't use this directly, although you can.
 
 =head1 SEE ALSO
 

--- a/lib/Valiant/Proxy/Hash.pm
+++ b/lib/Valiant/Proxy/Hash.pm
@@ -36,8 +36,7 @@ Valiant::Proxy::Hash - Wrap a hashref in a result object for validation.
 
 Allows you to run validations against a HashRef.
 
-You probably won't use this directly (although you can) since we have L<Valiant::Class> to
-encapsulate the most common patterns for this need.
+You probably won't use this directly, although you can.
 
 =head1 SEE ALSO
 

--- a/lib/Valiant/Proxy/Object.pm
+++ b/lib/Valiant/Proxy/Object.pm
@@ -63,8 +63,7 @@ I recommend you not use this approach in 'hot' code paths.  Its probably best if
 create all these during your application startup once (for long lived applications).  Maybe
 not ideal for 'fire and forget' scripts like cron jobs or CGI.
 
-You probably won't use this directly (although you can) since we have L<Valiant::Class> to
-encapsulate the most common patterns for this need.
+You probably won't use this directly, although you can.
 
 =head1 SEE ALSO
 

--- a/lib/Valiant/Validates.pm
+++ b/lib/Valiant/Validates.pm
@@ -467,7 +467,7 @@ arguments for the validate set as a whole:
 
 If you use a validator class name then the hashref of arguments that follows is not optional.  If you pass
 an options hashref it should contain arguments that are defined for the validation type you are passing
-or one of the global arguments: C<on>, C<message>, C<if> and C<unless>.  See L</"GLOBAL OPTIONS"> for more.
+or one of the global arguments C<on>, C<message>, C<if> and C<unless> (the shared parameters accepted by every validator).
 
 For subroutine reference and L<Type::Tiny> objects you can or not pass an options hashref depending on your
 needs.  Additionally the three types can be mixed and matched within a single C<validates> clause.

--- a/lib/Valiant/Validator/Date.pm
+++ b/lib/Valiant/Validator/Date.pm
@@ -192,7 +192,7 @@ which is commonly used in databases as a Date field and its also the canonical
 pattern for the HTML5 input date type.  
 
 Can accept a 'min' and 'max' attribute, which should be either a string in the 
-standard form or a M<DateTime> object.
+standard form or a L<DateTime> object.
 
 If you are using the Form helpers the max and min attributes can be reflected into
 the date input type automatically.

--- a/lib/Valiant/Validator/Hash.pm
+++ b/lib/Valiant/Validator/Hash.pm
@@ -170,13 +170,13 @@ or custom validator classes.
 
 =head2 validator
 
-This contains an instance of L<Valiant::Class> or subclass. Default value
+This contains an instance of L<Valiant::Proxy::Hash> or subclass. Default value
 does the right thing but you can override if you need a special subclass
 or you need to pass one in that's already constructed.
 
 =head2 validator_class 
 
-Defaults to L<Valiant::Class>, which value should be a subclass of.  You probably
+Defaults to L<Valiant::Proxy::Hash>, which value should be a subclass of.  You probably
 only need this again if you are doing very custom validations.  You probably only
 want do to this if there's no other idea.
 

--- a/lib/Valiant/Validator/Length.pm
+++ b/lib/Valiant/Validator/Length.pm
@@ -108,12 +108,12 @@ This validator supports the following constraints.
 
 =item maximum
 
-Accepts numeric value or coderef.  Returns error message tag V<too_long> if
+Accepts numeric value or coderef.  Returns error message tag C<too_long> if
 the attribute length exceeds the value.
 
 =item minimum
 
-Accepts numeric value or coderef.  Returns error message tag V<too_short> if
+Accepts numeric value or coderef.  Returns error message tag C<too_short> if
 the attribute length is smaller than the value.
 
 =item in
@@ -124,7 +124,7 @@ of either C<too_short> or C<too_long> if the value length is outside the range s
 
 =item is 
 
-Accepts numeric value or coderef.  Returns error message tag V<wrong_length> if
+Accepts numeric value or coderef.  Returns error message tag C<wrong_length> if
 the attribute value equal to the check value.
 
 =back

--- a/lib/Valiant/Validator/Numericality.pm
+++ b/lib/Valiant/Validator/Numericality.pm
@@ -241,32 +241,32 @@ also set it to the following to get more limited integer types:
 
 =item greater_than
 
-Accepts numeric value or coderef.  Returns error message tag V<greater_than> if
+Accepts numeric value or coderef.  Returns error message tag C<greater_than> if
 the attribute value isn't greater.
 
 =item greater_than_or_equal_to
 
-Accepts numeric value or coderef.  Returns error message tag V<greater_than_or_equal_to_err> if
+Accepts numeric value or coderef.  Returns error message tag C<greater_than_or_equal_to_err> if
 the attribute value isn't equal or greater.
 
 =item equal_to
 
-Accepts numeric value or coderef.  Returns error message tag V<equal_to_err> if
+Accepts numeric value or coderef.  Returns error message tag C<equal_to_err> if
 the attribute value isn't equal.
 
 =item other_than
 
-Accepts numeric value or coderef.  Returns error message tag V<other_than_err> if
+Accepts numeric value or coderef.  Returns error message tag C<other_than_err> if
 the attribute value isn't different.
 
 =item less_than
 
-Accepts numeric value or coderef.  Returns error message tag V<less_than_err> if
+Accepts numeric value or coderef.  Returns error message tag C<less_than_err> if
 the attribute value isn't less than.
 
 =item less_than_or_equal_to
 
-Accepts numeric value or coderef.  Returns error message tag V<less_than_or_equal_to_err> if
+Accepts numeric value or coderef.  Returns error message tag C<less_than_or_equal_to_err> if
 the attribute value isn't less than or equal.
 
 =item between
@@ -276,12 +276,12 @@ second is an inclusive upper number bound.
 
 =item even
 
-Accepts numeric value or coderef.  Returns error message tag V<even_err> if
+Accepts numeric value or coderef.  Returns error message tag C<even_err> if
 the attribute value isn't an even number.
 
 =item odd
 
-Accepts numeric value or coderef.  Returns error message tag V<odd_err> if
+Accepts numeric value or coderef.  Returns error message tag C<odd_err> if
 the attribute value isn't an odd number.
 
 =item divisible_by
@@ -293,7 +293,7 @@ divisible value was 4 that woule be false and generate an error message.
 
 =item decimals
 
-Accepts numeric value or coderef.  Returns error message tag V<decimals_err> if
+Accepts numeric value or coderef.  Returns error message tag C<decimals_err> if
 the attribute value doesn't contain exactly the requird number of places after
 the decimal point.
 


### PR DESCRIPTION
Cleanup of pre-existing POD defects surfaced by `podchecker` during the
minor-fixes work (PR #18). **Docs only — no code changes; full suite green
(61 files / 757 tests).**

Stacked on `minor-fixes` (base = that branch) because it edits many of the same
files; retarget to `main` once #18 merges.

## Fixes
- Invalid `V<>` formatting code → `C<>` in Length and Numericality (they wrapped
  error-tag names in a non-existent POD code).
- Invalid `M<DateTime>` → `L<DateTime>` in Date.
- `=over4` → `=over 4` in FormBuilder (broke the surrounding `=item` list).
- Validates: removed a broken internal link to a non-existent `GLOBAL OPTIONS`
  section; the four shared params are now described inline.
- **Purged the phantom `Valiant::Class`** (an abandoned experiment that never
  shipped and nothing depends on):
  - `Valiant::Proxy` SYNOPSIS now uses the real `Valiant::Proxy::Object` — and
    is corrected to the tested working form from `t/proxy.t` (the old synopsis
    couldn't run: it wrapped the callback so it never fired, and used
    `add(_base=>...)` which the proxy rejects). Verified it now produces its
    documented output.
  - The Object/Hash/Array proxy DESCRIPTIONs drop the "we have Valiant::Class"
    promise.
  - The Hash validator's `validator`/`validator_class` docs now name their real
    default, `Valiant::Proxy::Hash` (confirmed in code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)